### PR TITLE
omitempty for ramlx_version on index

### DIFF
--- a/metadata/ctipackage/index.go
+++ b/metadata/ctipackage/index.go
@@ -19,7 +19,7 @@ const (
 
 type Index struct {
 	PackageID            string            `json:"package_id"`
-	RamlxVersion         string            `json:"ramlx_version"`
+	RamlxVersion         string            `json:"ramlx_version,omitempty"`
 	Apis                 []string          `json:"apis,omitempty"`
 	Entities             []string          `json:"entities,omitempty"`
 	Assets               []string          `json:"assets,omitempty"`


### PR DESCRIPTION
This is needed when writing "index.json" using supplied Index struct.  If the "ramlx_version" is unset on the index, the produced file will have empty value.