### PR TITLE
fix zipWriter not setting archive

### DIFF
--- a/metadata/archiver/zippacker/archiver.go
+++ b/metadata/archiver/zippacker/archiver.go
@@ -36,6 +36,7 @@ func (zipWriter *zipWriter) Init(destination string) (io.Closer, error) {
 	if err != nil {
 		return nil, fmt.Errorf("create archive: %w", err)
 	}
+	zipWriter.archive = archive
 	zipWriter.Writer = *zip.NewWriter(archive)
 
 	return zipWriter, nil


### PR DESCRIPTION
Without this fix, `zipWriter` will always give error:
`pack the package: write sources: get archive info: invalid argument`