### PR TITLE
Fix CTI entity schemas merging

### DIFF
--- a/metadata/merger/merger.go
+++ b/metadata/merger/merger.go
@@ -116,14 +116,32 @@ func mergeRequired(source, target map[string]any) ([]string, error) {
 	// Use maps to simulate sets
 	requiredSet := make(map[any]struct{})
 
-	requiredSrc, _ := source[requiredKey].([]any)
-	for _, item := range requiredSrc {
-		requiredSet[item] = struct{}{}
+	// Extract source required fields
+	if src, ok := source[requiredKey]; ok {
+		switch typedSrc := src.(type) {
+		case []any:
+			for _, item := range typedSrc {
+				requiredSet[item] = struct{}{}
+			}
+		case []string:
+			for _, item := range typedSrc {
+				requiredSet[item] = struct{}{}
+			}
+		}
 	}
 
-	requiredTrg, _ := target[requiredKey].([]any)
-	for _, item := range requiredTrg {
-		requiredSet[item] = struct{}{}
+	// Extract target required fields
+	if trg, ok := target[requiredKey]; ok {
+		switch typedTrg := trg.(type) {
+		case []any:
+			for _, item := range typedTrg {
+				requiredSet[item] = struct{}{}
+			}
+		case []string:
+			for _, item := range typedTrg {
+				requiredSet[item] = struct{}{}
+			}
+		}
 	}
 
 	targetRequired := make([]string, 0, len(requiredSet))

--- a/metadata/merger/merger_test.go
+++ b/metadata/merger/merger_test.go
@@ -1,0 +1,80 @@
+package merger
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMergeRequired(t *testing.T) {
+	tests := []struct {
+		name     string
+		source   map[string]any
+		target   map[string]any
+		expected []string
+	}{
+		{
+			name: "simple required merge",
+			source: map[string]any{
+				"required": []any{"foo", "bar"},
+			},
+			target: map[string]any{
+				"required": []any{"baz", "bar"},
+			},
+			expected: []string{"foo", "bar", "baz"},
+		},
+		{
+			name:   "empty source required",
+			source: map[string]any{},
+			target: map[string]any{
+				"required": []any{"baz", "bar"},
+			},
+			expected: []string{"baz", "bar"},
+		},
+		{
+			name: "empty target required",
+			source: map[string]any{
+				"required": []any{"foo", "bar"},
+			},
+			target:   map[string]any{},
+			expected: []string{"foo", "bar"},
+		},
+		{
+			name: "source with string array",
+			source: map[string]any{
+				"required": []string{"foo", "bar"},
+			},
+			target: map[string]any{
+				"required": []any{"baz"},
+			},
+			expected: []string{"foo", "bar", "baz"},
+		},
+		{
+			name: "target with string array",
+			source: map[string]any{
+				"required": []any{"foo"},
+			},
+			target: map[string]any{
+				"required": []string{"baz", "bar"},
+			},
+			expected: []string{"foo", "baz", "bar"},
+		},
+		{
+			name: "multiple formats conversion resilience",
+			source: map[string]any{
+				"required": []string{"field1", "field2"}, // First as string array
+			},
+			target: map[string]any{
+				"required": []any{"field3", "field4"}, // Then as interface array
+			},
+			expected: []string{"field1", "field2", "field3", "field4"},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			required, err := mergeRequired(tc.source, tc.target)
+			require.NoError(t, err)
+			require.ElementsMatch(t, tc.expected, required)
+		})
+	}
+}


### PR DESCRIPTION
## Description
This PR fixes a bug within the metadata/merger package, where the "required" property wasn't being properly merged in nested schemas after multiple merge operations.

## Changes
- Enhanced the `mergeRequired` function to handle both `[]any` and `[]string` types using Go's type switch
- Added comprehensive test suite to verify proper merging behavior