### PR TITLE
refactor: convert UntypedEntity from struct to interface with convesion function

### DIFF
--- a/metadata/metadata_untyped.go
+++ b/metadata/metadata_untyped.go
@@ -2,32 +2,34 @@ package metadata
 
 import (
 	"encoding/json"
+	"fmt"
 
 	"github.com/acronis/go-cti/metadata/consts"
+	"github.com/acronis/go-cti/metadata/jsonschema"
 )
 
 type UntypedEntities []UntypedEntity
 
-// UntypedEntity represents an untyped CTI entity. It can be used to parse an entity of unknown type
-// and then convert it to a typed entity later.
-// Follows the same metadata structure as defined in the [CTI specification].
+// UntypedEntity is an interface for CTI entity that doesn't have a specific type defined at the time of creation.
+// Objects that implement this interface can be converted to the typed Entity using ConvertUntypedEntityToTypedEntity function.
+// See more information about CTI entities in the [CTI specification].
 //
 // [CTI specification]: https://github.com/acronis/go-cti/blob/main/cti-spec/SPEC.md#metadata-structure
-type UntypedEntity struct {
-	Final             bool                       `json:"final"`
-	CTI               string                     `json:"cti"`
-	Resilient         bool                       `json:"resilient"`
-	Access            consts.AccessModifier      `json:"access"`
-	DisplayName       string                     `json:"display_name,omitempty"`
-	Description       string                     `json:"description,omitempty"`
-	Dictionaries      map[string]any             `json:"dictionaries,omitempty"`
-	Values            json.RawMessage            `json:"values,omitempty"`
-	Schema            json.RawMessage            `json:"schema,omitempty"`
-	TraitsSchema      json.RawMessage            `json:"traits_schema,omitempty"`
-	TraitsAnnotations map[GJsonPath]*Annotations `json:"traits_annotations,omitempty"`
-	Traits            json.RawMessage            `json:"traits,omitempty"`
-	Annotations       map[GJsonPath]*Annotations `json:"annotations,omitempty"`
-	SourceMap         UntypedSourceMap           `json:"source_map,omitempty"`
+type UntypedEntity interface {
+	GetFinal() bool
+	GetCTI() string
+	GetResilient() bool
+	GetAccess() consts.AccessModifier
+	GetDisplayName() string
+	GetDescription() string
+	GetDictionaries() map[string]any
+	GetValues() json.RawMessage
+	GetSchema() json.RawMessage
+	GetTraitsSchema() json.RawMessage
+	GetTraitsAnnotations() json.RawMessage
+	GetTraits() json.RawMessage
+	GetAnnotations() json.RawMessage
+	GetSourceMap() UntypedSourceMap
 }
 
 type UntypedSourceMap struct {
@@ -47,4 +49,109 @@ type TypeAnnotationReference struct {
 
 type InstanceAnnotationReference struct {
 	AnnotationType *AnnotationType `json:"$annotationType,omitempty"`
+}
+
+// ConvertUntypedEntityToTypedEntity converts an UntypedEntity to a typed Entity.
+// It checks if the entity has a schema or values, and creates either an EntityType or EntityInstance accordingly.
+// If the entity has both schema and values, or neither, it returns an error.
+func ConvertUntypedEntityToTypedEntity(untypedEntity UntypedEntity) (Entity, error) {
+	rawSchema := untypedEntity.GetSchema()
+	rawValues := untypedEntity.GetValues()
+	if rawSchema == nil && rawValues == nil {
+		return nil, fmt.Errorf("untyped entity %s has neither schema nor values", untypedEntity.GetCTI())
+	}
+	if rawValues != nil && rawSchema != nil {
+		return nil, fmt.Errorf("untyped entity %s has both schema and values, only one is allowed", untypedEntity.GetCTI())
+	}
+
+	// If the entity has values but no schema, we treat it as an instance of an entity type.
+	if rawValues != nil {
+		e, err := NewEntityInstance(untypedEntity.GetCTI(), rawValues)
+		if err != nil {
+			return nil, fmt.Errorf("make entity instance: %w", err)
+		}
+		if !untypedEntity.GetFinal() {
+			return nil, fmt.Errorf("untyped entity %s is not final, cannot convert to typed entity instance", untypedEntity.GetCTI())
+		}
+		if untypedEntity.GetTraitsSchema() != nil {
+			return nil, fmt.Errorf("untyped entity %s has traits schema, but it is not allowed for entity instances", untypedEntity.GetCTI())
+		}
+		if untypedEntity.GetTraits() != nil {
+			return nil, fmt.Errorf("untyped entity %s has traits, but it is not allowed for entity instances", untypedEntity.GetCTI())
+		}
+		if untypedEntity.GetTraitsAnnotations() != nil {
+			return nil, fmt.Errorf("untyped entity %s has traits annotations, but it is not allowed for entity instances", untypedEntity.GetCTI())
+		}
+		if untypedEntity.GetAnnotations() != nil {
+			return nil, fmt.Errorf("untyped entity %s has annotations, but it is not allowed for entity instances", untypedEntity.GetCTI())
+		}
+		e.SetFinal(true)
+		e.SetResilient(untypedEntity.GetResilient())
+		e.SetAccess(untypedEntity.GetAccess())
+		e.SetDisplayName(untypedEntity.GetDisplayName())
+		e.SetDescription(untypedEntity.GetDescription())
+		untypedSourceMap := untypedEntity.GetSourceMap()
+		var annotationType AnnotationType
+		if untypedSourceMap.AnnotationType != nil {
+			annotationType = *untypedSourceMap.AnnotationType
+		}
+		e.SetSourceMap(EntityInstanceSourceMap{
+			AnnotationType: annotationType,
+			EntitySourceMap: EntitySourceMap{
+				OriginalPath: untypedSourceMap.OriginalPath,
+				SourcePath:   untypedSourceMap.SourcePath,
+			},
+		})
+		return e, nil
+	}
+
+	// If the entity has a schema, we treat it as an entity type.
+	var schema jsonschema.JSONSchemaCTI
+	if err := json.Unmarshal(rawSchema, &schema); err != nil {
+		return nil, fmt.Errorf("unmarshal schema for %s: %w", untypedEntity.GetCTI(), err)
+	}
+	var annotations map[GJsonPath]*Annotations
+	if rawAnnotations := untypedEntity.GetAnnotations(); rawAnnotations != nil {
+		if err := json.Unmarshal(rawAnnotations, &annotations); err != nil {
+			return nil, fmt.Errorf("unmarshal annotations for %s: %w", untypedEntity.GetCTI(), err)
+		}
+	}
+	e, err := NewEntityType(untypedEntity.GetCTI(), &schema, annotations)
+	if err != nil {
+		return nil, fmt.Errorf("make entity type: %w", err)
+	}
+	e.SetFinal(untypedEntity.GetFinal())
+	e.SetResilient(untypedEntity.GetResilient())
+	e.SetAccess(untypedEntity.GetAccess())
+	e.SetDisplayName(untypedEntity.GetDisplayName())
+	e.SetDescription(untypedEntity.GetDescription())
+	if rawTraitsSchema := untypedEntity.GetTraitsSchema(); rawTraitsSchema != nil {
+		var traitsSchema jsonschema.JSONSchemaCTI
+		if err = json.Unmarshal(rawTraitsSchema, &traitsSchema); err != nil {
+			return nil, fmt.Errorf("unmarshal traits schema for %s: %w", untypedEntity.GetCTI(), err)
+		}
+		var traitsAnnotations map[GJsonPath]*Annotations
+		if rawTraitsAnnotations := untypedEntity.GetTraitsAnnotations(); rawTraitsAnnotations != nil {
+			if err = json.Unmarshal(rawTraitsAnnotations, &traitsAnnotations); err != nil {
+				return nil, fmt.Errorf("unmarshal traits annotations for %s: %w", untypedEntity.GetCTI(), err)
+			}
+		}
+		e.SetTraitsSchema(&traitsSchema, traitsAnnotations)
+	}
+	if rawTraits := untypedEntity.GetTraits(); rawTraits != nil {
+		var traits map[string]any
+		if err = json.Unmarshal(rawTraits, &traits); err != nil {
+			return nil, fmt.Errorf("unmarshal traits for %s: %w", untypedEntity.GetCTI(), err)
+		}
+		e.SetTraits(traits)
+	}
+	untypedSourceMap := untypedEntity.GetSourceMap()
+	e.SetSourceMap(EntityTypeSourceMap{
+		Name: untypedSourceMap.Name,
+		EntitySourceMap: EntitySourceMap{
+			OriginalPath: untypedSourceMap.OriginalPath,
+			SourcePath:   untypedSourceMap.SourcePath,
+		},
+	})
+	return e, nil
 }

--- a/metadata/metadata_untyped_test.go
+++ b/metadata/metadata_untyped_test.go
@@ -1,0 +1,628 @@
+package metadata
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/acronis/go-cti/metadata/consts"
+	"github.com/acronis/go-cti/metadata/jsonschema"
+	"github.com/stretchr/testify/require"
+	orderedmap "github.com/wk8/go-ordered-map/v2"
+)
+
+// testUntypedEntity is a test implementation of UntypedEntity interface
+type testUntypedEntity struct {
+	Final             bool
+	CTI               string
+	Resilient         bool
+	Access            consts.AccessModifier
+	DisplayName       string
+	Description       string
+	Dictionaries      map[string]any
+	Values            json.RawMessage
+	Schema            json.RawMessage
+	TraitsSchema      json.RawMessage
+	TraitsAnnotations json.RawMessage
+	Traits            json.RawMessage
+	Annotations       json.RawMessage
+	SourceMap         UntypedSourceMap
+}
+
+func (te *testUntypedEntity) GetFinal() bool                        { return te.Final }
+func (te *testUntypedEntity) GetCTI() string                        { return te.CTI }
+func (te *testUntypedEntity) GetResilient() bool                    { return te.Resilient }
+func (te *testUntypedEntity) GetAccess() consts.AccessModifier      { return te.Access }
+func (te *testUntypedEntity) GetDisplayName() string                { return te.DisplayName }
+func (te *testUntypedEntity) GetDescription() string                { return te.Description }
+func (te *testUntypedEntity) GetDictionaries() map[string]any       { return te.Dictionaries }
+func (te *testUntypedEntity) GetValues() json.RawMessage            { return te.Values }
+func (te *testUntypedEntity) GetSchema() json.RawMessage            { return te.Schema }
+func (te *testUntypedEntity) GetTraitsSchema() json.RawMessage      { return te.TraitsSchema }
+func (te *testUntypedEntity) GetTraitsAnnotations() json.RawMessage { return te.TraitsAnnotations }
+func (te *testUntypedEntity) GetTraits() json.RawMessage            { return te.Traits }
+func (te *testUntypedEntity) GetAnnotations() json.RawMessage       { return te.Annotations }
+func (te *testUntypedEntity) GetSourceMap() UntypedSourceMap        { return te.SourceMap }
+
+func TestConvertUntypedEntityToTypedEntity_EntityInstance(t *testing.T) {
+	tests := []struct {
+		name          string
+		untypedEntity *testUntypedEntity
+		wantErr       bool
+		errContains   string
+		validate      func(t *testing.T, entity Entity)
+	}{
+		{
+			name: "valid entity instance",
+			untypedEntity: &testUntypedEntity{
+				CTI:         "cti.test.instance.v1.0",
+				Final:       true,
+				Resilient:   true,
+				Access:      consts.AccessModifierPublic,
+				DisplayName: "Test Instance",
+				Description: "A test entity instance",
+				Values:      json.RawMessage(`{"field1": "value1", "field2": 42}`),
+				SourceMap: UntypedSourceMap{
+					InstanceAnnotationReference: InstanceAnnotationReference{
+						AnnotationType: &AnnotationType{Name: "TestInstance"},
+					},
+					SourcePath:   "test/instance.raml",
+					OriginalPath: "test/original.raml",
+				},
+			},
+			wantErr: false,
+			validate: func(t *testing.T, entity Entity) {
+				require.Equal(t, "cti.test.instance.v1.0", entity.GetCTI())
+				require.True(t, entity.IsFinal())
+				require.Equal(t, consts.AccessModifierPublic, entity.GetAccess())
+
+				instance, ok := entity.(*EntityInstance)
+				require.True(t, ok)
+				require.True(t, instance.Resilient)
+				require.Equal(t, "Test Instance", instance.DisplayName)
+				require.Equal(t, "A test entity instance", instance.Description)
+				// The Values field stores the raw JSON message as-is
+				require.Equal(t, json.RawMessage(`{"field1": "value1", "field2": 42}`), instance.Values)
+
+				require.Equal(t, "TestInstance", instance.SourceMap.AnnotationType.Name)
+				require.Equal(t, "test/instance.raml", instance.SourceMap.SourcePath)
+				require.Equal(t, "test/original.raml", instance.SourceMap.OriginalPath)
+			},
+		},
+		{
+			name: "entity instance with non-final flag should fail",
+			untypedEntity: &testUntypedEntity{
+				CTI:    "cti.test.instance.v1.0",
+				Final:  false,
+				Values: json.RawMessage(`{"field1": "value1"}`),
+			},
+			wantErr:     true,
+			errContains: "is not final, cannot convert to typed entity instance",
+		},
+		{
+			name: "entity instance with traits schema should fail",
+			untypedEntity: &testUntypedEntity{
+				CTI:          "cti.test.instance.v1.0",
+				Final:        true,
+				Values:       json.RawMessage(`{"field1": "value1"}`),
+				TraitsSchema: json.RawMessage(`{"type": "object"}`),
+			},
+			wantErr:     true,
+			errContains: "has traits schema, but it is not allowed for entity instances",
+		},
+		{
+			name: "entity instance with traits should fail",
+			untypedEntity: &testUntypedEntity{
+				CTI:    "cti.test.instance.v1.0",
+				Final:  true,
+				Values: json.RawMessage(`{"field1": "value1"}`),
+				Traits: json.RawMessage(`{"trait1": "value1"}`),
+			},
+			wantErr:     true,
+			errContains: "has traits, but it is not allowed for entity instances",
+		},
+		{
+			name: "entity instance with traits annotations should fail",
+			untypedEntity: &testUntypedEntity{
+				CTI:               "cti.test.instance.v1.0",
+				Final:             true,
+				Values:            json.RawMessage(`{"field1": "value1"}`),
+				TraitsAnnotations: json.RawMessage(`{".": {"cti": "test"}}`),
+			},
+			wantErr:     true,
+			errContains: "has traits annotations, but it is not allowed for entity instances",
+		},
+		{
+			name: "entity instance with annotations should fail",
+			untypedEntity: &testUntypedEntity{
+				CTI:         "cti.test.instance.v1.0",
+				Final:       true,
+				Values:      json.RawMessage(`{"field1": "value1"}`),
+				Annotations: json.RawMessage(`{".": {"cti": "test"}}`),
+			},
+			wantErr:     true,
+			errContains: "has annotations, but it is not allowed for entity instances",
+		},
+		{
+			name: "entity instance with invalid values JSON",
+			untypedEntity: &testUntypedEntity{
+				CTI:    "cti.test.instance.v1.0",
+				Final:  true,
+				Values: json.RawMessage(`invalid json`),
+			},
+			wantErr: false, // Actually, NewEntityInstance will succeed with invalid JSON - it's just stored as RawMessage
+			validate: func(t *testing.T, entity Entity) {
+				// The invalid JSON is stored as-is until it's actually used
+				instance, ok := entity.(*EntityInstance)
+				require.True(t, ok)
+				// The raw JSON is stored directly in Values field
+				require.Equal(t, json.RawMessage(`invalid json`), instance.Values)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			entity, err := ConvertUntypedEntityToTypedEntity(tt.untypedEntity)
+			if tt.wantErr {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.errContains)
+				require.Nil(t, entity)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, entity)
+				tt.validate(t, entity)
+			}
+		})
+	}
+}
+
+func TestConvertUntypedEntityToTypedEntity_EntityType(t *testing.T) {
+	simpleSchema := &jsonschema.JSONSchemaCTI{
+		JSONSchemaGeneric: jsonschema.JSONSchemaGeneric{
+			Version: "http://json-schema.org/draft-07/schema",
+			Type:    "object",
+			Properties: orderedmap.New[string, *jsonschema.JSONSchemaCTI](
+				orderedmap.WithInitialData([]orderedmap.Pair[string, *jsonschema.JSONSchemaCTI]{
+					{Key: "name", Value: &jsonschema.JSONSchemaCTI{JSONSchemaGeneric: jsonschema.JSONSchemaGeneric{Type: "string"}}},
+					{Key: "age", Value: &jsonschema.JSONSchemaCTI{JSONSchemaGeneric: jsonschema.JSONSchemaGeneric{Type: "integer"}}},
+				}...),
+			),
+		},
+	}
+	simpleSchemaJSON, _ := json.Marshal(simpleSchema)
+
+	traitsSchema := &jsonschema.JSONSchemaCTI{
+		JSONSchemaGeneric: jsonschema.JSONSchemaGeneric{
+			Type: "object",
+			Properties: orderedmap.New[string, *jsonschema.JSONSchemaCTI](
+				orderedmap.WithInitialData([]orderedmap.Pair[string, *jsonschema.JSONSchemaCTI]{
+					{Key: "trait1", Value: &jsonschema.JSONSchemaCTI{JSONSchemaGeneric: jsonschema.JSONSchemaGeneric{Type: "string"}}},
+				}...),
+			),
+		},
+	}
+	traitsSchemaJSON, _ := json.Marshal(traitsSchema)
+
+	tests := []struct {
+		name          string
+		untypedEntity *testUntypedEntity
+		wantErr       bool
+		errContains   string
+		validate      func(t *testing.T, entity Entity)
+	}{
+		{
+			name: "valid entity type",
+			untypedEntity: &testUntypedEntity{
+				CTI:         "cti.test.type.v1.0",
+				Final:       false,
+				Resilient:   true,
+				Access:      consts.AccessModifierPrivate,
+				DisplayName: "Test Type",
+				Description: "A test entity type",
+				Schema:      simpleSchemaJSON,
+				Annotations: json.RawMessage(`{}`), // Empty but not nil
+				SourceMap: UntypedSourceMap{
+					TypeAnnotationReference: TypeAnnotationReference{
+						Name: "TestType",
+					},
+					SourcePath:   "test/type.raml",
+					OriginalPath: "test/original.raml",
+				},
+			},
+			wantErr: false,
+			validate: func(t *testing.T, entity Entity) {
+				require.Equal(t, "cti.test.type.v1.0", entity.GetCTI())
+				require.False(t, entity.IsFinal())
+				require.Equal(t, consts.AccessModifierPrivate, entity.GetAccess())
+
+				entityType, ok := entity.(*EntityType)
+				require.True(t, ok)
+				require.True(t, entityType.Resilient)
+				require.Equal(t, "Test Type", entityType.DisplayName)
+				require.Equal(t, "A test entity type", entityType.Description)
+				require.NotNil(t, entityType.Schema)
+				require.Equal(t, "object", entityType.Schema.Type)
+
+				require.Equal(t, "TestType", entityType.SourceMap.Name)
+				require.Equal(t, "test/type.raml", entityType.SourceMap.SourcePath)
+				require.Equal(t, "test/original.raml", entityType.SourceMap.OriginalPath)
+			},
+		},
+		{
+			name: "entity type with traits schema and traits",
+			untypedEntity: &testUntypedEntity{
+				CTI:          "cti.test.type.v1.0",
+				Final:        true,
+				Schema:       simpleSchemaJSON,
+				Annotations:  json.RawMessage(`{}`), // Empty but not nil
+				TraitsSchema: traitsSchemaJSON,
+				Traits:       json.RawMessage(`{"trait1": "traitValue"}`),
+			},
+			wantErr: false,
+			validate: func(t *testing.T, entity Entity) {
+				entityType, ok := entity.(*EntityType)
+				require.True(t, ok)
+				require.True(t, entity.IsFinal())
+
+				require.NotNil(t, entityType.TraitsSchema)
+				require.Equal(t, "object", entityType.TraitsSchema.Type)
+
+				require.NotNil(t, entityType.Traits)
+				require.Equal(t, map[string]any{"trait1": "traitValue"}, entityType.Traits)
+			},
+		},
+		{
+			name: "entity type with annotations",
+			untypedEntity: &testUntypedEntity{
+				CTI:         "cti.test.type.v1.0",
+				Schema:      simpleSchemaJSON,
+				Annotations: json.RawMessage(`{".": {"cti.cti": "test.annotation"}}`), // Fixed JSON key
+			},
+			wantErr: false,
+			validate: func(t *testing.T, entity Entity) {
+				annotations := entity.GetAnnotations()
+				require.NotNil(t, annotations)
+				require.Contains(t, annotations, GJsonPath("."))
+				require.Equal(t, "test.annotation", annotations["."].CTI)
+			},
+		},
+		{
+			name: "entity type with traits annotations",
+			untypedEntity: &testUntypedEntity{
+				CTI:               "cti.test.type.v1.0",
+				Schema:            simpleSchemaJSON,
+				Annotations:       json.RawMessage(`{}`), // Empty but not nil
+				TraitsSchema:      traitsSchemaJSON,
+				TraitsAnnotations: json.RawMessage(`{".trait1": {"cti.cti": "trait.annotation"}}`), // Fixed JSON key
+			},
+			wantErr: false,
+			validate: func(t *testing.T, entity Entity) {
+				entityType, ok := entity.(*EntityType)
+				require.True(t, ok)
+				require.NotNil(t, entityType.TraitsAnnotations)
+				require.Contains(t, entityType.TraitsAnnotations, GJsonPath(".trait1"))
+				require.Equal(t, "trait.annotation", entityType.TraitsAnnotations[".trait1"].CTI)
+			},
+		},
+		{
+			name: "entity type with invalid schema JSON",
+			untypedEntity: &testUntypedEntity{
+				CTI:    "cti.test.type.v1.0",
+				Schema: json.RawMessage(`invalid json`),
+			},
+			wantErr:     true,
+			errContains: "unmarshal schema for",
+		},
+		{
+			name: "entity type with invalid annotations JSON",
+			untypedEntity: &testUntypedEntity{
+				CTI:         "cti.test.type.v1.0",
+				Schema:      simpleSchemaJSON,
+				Annotations: json.RawMessage(`invalid json`),
+			},
+			wantErr:     true,
+			errContains: "unmarshal annotations for",
+		},
+		{
+			name: "entity type with invalid traits schema JSON",
+			untypedEntity: &testUntypedEntity{
+				CTI:          "cti.test.type.v1.0",
+				Schema:       simpleSchemaJSON,
+				Annotations:  json.RawMessage(`{}`), // Empty but not nil
+				TraitsSchema: json.RawMessage(`invalid json`),
+			},
+			wantErr:     true,
+			errContains: "unmarshal traits schema for",
+		},
+		{
+			name: "entity type with invalid traits annotations JSON",
+			untypedEntity: &testUntypedEntity{
+				CTI:               "cti.test.type.v1.0",
+				Schema:            simpleSchemaJSON,
+				Annotations:       json.RawMessage(`{}`), // Empty but not nil
+				TraitsSchema:      traitsSchemaJSON,
+				TraitsAnnotations: json.RawMessage(`invalid json`),
+			},
+			wantErr:     true,
+			errContains: "unmarshal traits annotations for",
+		},
+		{
+			name: "entity type with invalid traits JSON",
+			untypedEntity: &testUntypedEntity{
+				CTI:         "cti.test.type.v1.0",
+				Schema:      simpleSchemaJSON,
+				Annotations: json.RawMessage(`{}`), // Empty but not nil
+				Traits:      json.RawMessage(`invalid json`),
+			},
+			wantErr:     true,
+			errContains: "unmarshal traits for",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			entity, err := ConvertUntypedEntityToTypedEntity(tt.untypedEntity)
+			if tt.wantErr {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.errContains)
+				require.Nil(t, entity)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, entity)
+				tt.validate(t, entity)
+			}
+		})
+	}
+}
+
+func TestConvertUntypedEntityToTypedEntity_ErrorCases(t *testing.T) {
+	tests := []struct {
+		name          string
+		untypedEntity *testUntypedEntity
+		wantErr       bool
+		errContains   string
+	}{
+		{
+			name: "entity with neither schema nor values",
+			untypedEntity: &testUntypedEntity{
+				CTI: "cti.test.empty.v1.0",
+			},
+			wantErr:     true,
+			errContains: "has neither schema nor values",
+		},
+		{
+			name: "entity with both schema and values",
+			untypedEntity: &testUntypedEntity{
+				CTI:    "cti.test.both.v1.0",
+				Schema: json.RawMessage(`{"type": "object"}`),
+				Values: json.RawMessage(`{"field1": "value1"}`),
+			},
+			wantErr:     true,
+			errContains: "has both schema and values, only one is allowed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			entity, err := ConvertUntypedEntityToTypedEntity(tt.untypedEntity)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tt.errContains)
+			require.Nil(t, entity)
+		})
+	}
+}
+
+func TestConvertUntypedEntityToTypedEntity_ComplexEntityType(t *testing.T) {
+	// Create a complex schema with definitions and references
+	complexSchema := &jsonschema.JSONSchemaCTI{
+		JSONSchemaGeneric: jsonschema.JSONSchemaGeneric{
+			Version: "http://json-schema.org/draft-07/schema",
+			Ref:     "#/definitions/Person",
+			Definitions: map[string]*jsonschema.JSONSchemaCTI{
+				"Person": {
+					JSONSchemaGeneric: jsonschema.JSONSchemaGeneric{
+						Type: "object",
+						Properties: orderedmap.New[string, *jsonschema.JSONSchemaCTI](
+							orderedmap.WithInitialData([]orderedmap.Pair[string, *jsonschema.JSONSchemaCTI]{
+								{Key: "name", Value: &jsonschema.JSONSchemaCTI{JSONSchemaGeneric: jsonschema.JSONSchemaGeneric{Type: "string"}}},
+								{Key: "address", Value: &jsonschema.JSONSchemaCTI{JSONSchemaGeneric: jsonschema.JSONSchemaGeneric{Ref: "#/definitions/Address"}}},
+							}...),
+						),
+					},
+				},
+				"Address": {
+					JSONSchemaGeneric: jsonschema.JSONSchemaGeneric{
+						Type: "object",
+						Properties: orderedmap.New[string, *jsonschema.JSONSchemaCTI](
+							orderedmap.WithInitialData([]orderedmap.Pair[string, *jsonschema.JSONSchemaCTI]{
+								{Key: "street", Value: &jsonschema.JSONSchemaCTI{JSONSchemaGeneric: jsonschema.JSONSchemaGeneric{Type: "string"}}},
+								{Key: "city", Value: &jsonschema.JSONSchemaCTI{JSONSchemaGeneric: jsonschema.JSONSchemaGeneric{Type: "string"}}},
+							}...),
+						),
+					},
+				},
+			},
+		},
+	}
+	complexSchemaJSON, _ := json.Marshal(complexSchema)
+
+	untypedEntity := &testUntypedEntity{
+		CTI:         "cti.test.complex.v1.0",
+		Final:       false,
+		Resilient:   true,
+		Access:      consts.AccessModifierProtected,
+		DisplayName: "Complex Entity Type",
+		Description: "A complex entity type with nested schemas",
+		Schema:      complexSchemaJSON,
+		Annotations: json.RawMessage(`{
+			".": {"cti.cti": "root.annotation"},
+			".name": {"cti.schema": "string.schema"},
+			".address": {"cti.cti": "address.annotation"}
+		}`),
+		TraitsSchema: json.RawMessage(`{
+			"type": "object",
+			"properties": {
+				"timestamps": {
+					"type": "object",
+					"properties": {
+						"created": {"type": "string", "format": "date-time"},
+						"updated": {"type": "string", "format": "date-time"}
+					}
+				}
+			}
+		}`),
+		TraitsAnnotations: json.RawMessage(`{
+			".timestamps": {"cti.cti": "timestamps.trait"},
+			".timestamps.created": {"cti.meta": "iso8601"}
+		}`),
+		Traits: json.RawMessage(`{
+			"timestamps": {
+				"created": "2023-01-01T00:00:00Z",
+				"updated": "2023-01-02T00:00:00Z"
+			}
+		}`),
+		SourceMap: UntypedSourceMap{
+			TypeAnnotationReference: TypeAnnotationReference{
+				Name: "ComplexType",
+			},
+			SourcePath:   "complex/type.raml",
+			OriginalPath: "complex/original.raml",
+		},
+	}
+
+	entity, err := ConvertUntypedEntityToTypedEntity(untypedEntity)
+	require.NoError(t, err)
+	require.NotNil(t, entity)
+
+	// Validate basic properties
+	require.Equal(t, "cti.test.complex.v1.0", entity.GetCTI())
+	require.False(t, entity.IsFinal())
+	require.Equal(t, consts.AccessModifierProtected, entity.GetAccess())
+
+	// Validate it's an EntityType
+	entityType, ok := entity.(*EntityType)
+	require.True(t, ok)
+	require.True(t, entityType.Resilient)
+	require.Equal(t, "Complex Entity Type", entityType.DisplayName)
+	require.Equal(t, "A complex entity type with nested schemas", entityType.Description)
+
+	// Validate complex schema
+	require.NotNil(t, entityType.Schema)
+	require.Equal(t, "#/definitions/Person", entityType.Schema.Ref)
+	require.Contains(t, entityType.Schema.Definitions, "Person")
+	require.Contains(t, entityType.Schema.Definitions, "Address")
+
+	// Validate annotations
+	annotations := entity.GetAnnotations()
+	require.NotNil(t, annotations)
+	require.Contains(t, annotations, GJsonPath("."))
+	require.Contains(t, annotations, GJsonPath(".name"))
+	require.Contains(t, annotations, GJsonPath(".address"))
+	require.Equal(t, "root.annotation", annotations["."].CTI)
+
+	// Validate traits schema
+	require.NotNil(t, entityType.TraitsSchema)
+	require.Equal(t, "object", entityType.TraitsSchema.Type)
+
+	// Validate traits annotations
+	require.NotNil(t, entityType.TraitsAnnotations)
+	require.Contains(t, entityType.TraitsAnnotations, GJsonPath(".timestamps"))
+	require.Contains(t, entityType.TraitsAnnotations, GJsonPath(".timestamps.created"))
+
+	// Validate traits
+	require.NotNil(t, entityType.Traits)
+	timestamps, ok := entityType.Traits["timestamps"].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "2023-01-01T00:00:00Z", timestamps["created"])
+	require.Equal(t, "2023-01-02T00:00:00Z", timestamps["updated"])
+
+	// Validate source map
+	require.Equal(t, "ComplexType", entityType.SourceMap.Name)
+	require.Equal(t, "complex/type.raml", entityType.SourceMap.SourcePath)
+	require.Equal(t, "complex/original.raml", entityType.SourceMap.OriginalPath)
+}
+
+func TestConvertUntypedEntityToTypedEntity_EdgeCases(t *testing.T) {
+	tests := []struct {
+		name          string
+		untypedEntity *testUntypedEntity
+		wantErr       bool
+		errContains   string
+		validate      func(t *testing.T, entity Entity)
+	}{
+		{
+			name: "entity instance with nil annotation type in source map",
+			untypedEntity: &testUntypedEntity{
+				CTI:    "cti.test.instance.v1.0",
+				Final:  true,
+				Values: json.RawMessage(`{"field1": "value1"}`),
+				SourceMap: UntypedSourceMap{
+					InstanceAnnotationReference: InstanceAnnotationReference{
+						AnnotationType: nil, // nil annotation type
+					},
+					SourcePath:   "test/instance.raml",
+					OriginalPath: "test/original.raml",
+				},
+			},
+			wantErr: false,
+			validate: func(t *testing.T, entity Entity) {
+				instance, ok := entity.(*EntityInstance)
+				require.True(t, ok)
+				require.Equal(t, AnnotationType{}, instance.SourceMap.AnnotationType) // Should be zero value
+			},
+		},
+		{
+			name: "entity type with empty traits and annotations",
+			untypedEntity: &testUntypedEntity{
+				CTI:               "cti.test.type.v1.0",
+				Schema:            json.RawMessage(`{"type": "object"}`),
+				Traits:            json.RawMessage(`{}`),
+				Annotations:       json.RawMessage(`{}`), // Empty but not nil - this is valid
+				TraitsAnnotations: json.RawMessage(`{}`),
+			},
+			wantErr: false,
+			validate: func(t *testing.T, entity Entity) {
+				entityType, ok := entity.(*EntityType)
+				require.True(t, ok)
+				require.Empty(t, entityType.Traits)
+				require.Empty(t, entity.GetAnnotations())
+				require.Empty(t, entityType.TraitsAnnotations)
+			},
+		},
+		{
+			name: "entity with minimal required fields only",
+			untypedEntity: &testUntypedEntity{
+				CTI:         "cti.minimal.v1.0",
+				Schema:      json.RawMessage(`{"type": "string"}`),
+				Annotations: json.RawMessage(`{}`), // Empty but not nil
+			},
+			wantErr: false,
+			validate: func(t *testing.T, entity Entity) {
+				require.Equal(t, "cti.minimal.v1.0", entity.GetCTI())
+				require.False(t, entity.IsFinal())
+				require.Equal(t, consts.AccessModifier(""), entity.GetAccess())
+
+				entityType, ok := entity.(*EntityType)
+				require.True(t, ok)
+				require.False(t, entityType.Resilient)
+				require.Equal(t, "", entityType.DisplayName)
+				require.Equal(t, "", entityType.Description)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			entity, err := ConvertUntypedEntityToTypedEntity(tt.untypedEntity)
+			if tt.wantErr {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.errContains)
+				require.Nil(t, entity)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, entity)
+				tt.validate(t, entity)
+			}
+		})
+	}
+}


### PR DESCRIPTION
- Convert UntypedEntity from concrete struct to interface pattern
- Add ConvertUntypedEntityToTypedEntity function for unified entity conversion
- Create CachedEntity struct implementing UntypedEntity interface for parser
- Add comprehensive test coverage for entity conversion scenarios