### PR TITLE
refactor: rename ConvertUntypedEntityToTypedEntity to ConvertUntypedEntityToEntity

### DIFF
--- a/metadata/ctipackage/parser.go
+++ b/metadata/ctipackage/parser.go
@@ -241,7 +241,7 @@ func (pkg *Package) loadEntitiesFromCache(cacheFile string) (metadata.Entities, 
 
 	entities := make(metadata.Entities, len(cachedEntities))
 	for i, cachedEntity := range cachedEntities {
-		entity, convErr := metadata.ConvertUntypedEntityToTypedEntity(&cachedEntity)
+		entity, convErr := metadata.ConvertUntypedEntityToEntity(&cachedEntity)
 		if convErr != nil {
 			return nil, fmt.Errorf("convert cached entity to typed entity: %w", convErr)
 		}

--- a/metadata/metadata_untyped.go
+++ b/metadata/metadata_untyped.go
@@ -11,7 +11,7 @@ import (
 type UntypedEntities []UntypedEntity
 
 // UntypedEntity is an interface for CTI entity that doesn't have a specific type defined at the time of creation.
-// Objects that implement this interface can be converted to the typed Entity using ConvertUntypedEntityToTypedEntity function.
+// Objects that implement this interface can be converted to the typed Entity using ConvertUntypedEntityToEntity function.
 // See more information about CTI entities in the [CTI specification].
 //
 // [CTI specification]: https://github.com/acronis/go-cti/blob/main/cti-spec/SPEC.md#metadata-structure
@@ -51,10 +51,10 @@ type InstanceAnnotationReference struct {
 	AnnotationType AnnotationType `json:"$annotationType,omitempty"`
 }
 
-// ConvertUntypedEntityToTypedEntity converts an UntypedEntity to a typed Entity.
+// ConvertUntypedEntityToEntity converts an UntypedEntity to a typed Entity.
 // It checks if the entity has a schema or values, and creates either an EntityType or EntityInstance accordingly.
 // If the entity has both schema and values, or neither, it returns an error.
-func ConvertUntypedEntityToTypedEntity(untypedEntity UntypedEntity) (Entity, error) {
+func ConvertUntypedEntityToEntity(untypedEntity UntypedEntity) (Entity, error) {
 	rawSchema := untypedEntity.GetSchema()
 	rawValues := untypedEntity.GetValues()
 	if rawSchema == nil && rawValues == nil {

--- a/metadata/metadata_untyped_test.go
+++ b/metadata/metadata_untyped_test.go
@@ -43,7 +43,7 @@ func (te *testUntypedEntity) GetTraits() json.RawMessage            { return te.
 func (te *testUntypedEntity) GetAnnotations() json.RawMessage       { return te.Annotations }
 func (te *testUntypedEntity) GetSourceMap() UntypedSourceMap        { return te.SourceMap }
 
-func TestConvertUntypedEntityToTypedEntity_EntityInstance(t *testing.T) {
+func TestConvertUntypedEntityToEntity_EntityInstance(t *testing.T) {
 	tests := []struct {
 		name          string
 		untypedEntity *testUntypedEntity
@@ -167,7 +167,7 @@ func TestConvertUntypedEntityToTypedEntity_EntityInstance(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			entity, err := ConvertUntypedEntityToTypedEntity(tt.untypedEntity)
+			entity, err := ConvertUntypedEntityToEntity(tt.untypedEntity)
 			if tt.wantErr {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), tt.errContains)
@@ -181,7 +181,7 @@ func TestConvertUntypedEntityToTypedEntity_EntityInstance(t *testing.T) {
 	}
 }
 
-func TestConvertUntypedEntityToTypedEntity_EntityType(t *testing.T) {
+func TestConvertUntypedEntityToEntity_EntityType(t *testing.T) {
 	simpleSchema := &jsonschema.JSONSchemaCTI{
 		JSONSchemaGeneric: jsonschema.JSONSchemaGeneric{
 			Version: "http://json-schema.org/draft-07/schema",
@@ -366,7 +366,7 @@ func TestConvertUntypedEntityToTypedEntity_EntityType(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			entity, err := ConvertUntypedEntityToTypedEntity(tt.untypedEntity)
+			entity, err := ConvertUntypedEntityToEntity(tt.untypedEntity)
 			if tt.wantErr {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), tt.errContains)
@@ -380,7 +380,7 @@ func TestConvertUntypedEntityToTypedEntity_EntityType(t *testing.T) {
 	}
 }
 
-func TestConvertUntypedEntityToTypedEntity_ErrorCases(t *testing.T) {
+func TestConvertUntypedEntityToEntity_ErrorCases(t *testing.T) {
 	tests := []struct {
 		name          string
 		untypedEntity *testUntypedEntity
@@ -409,7 +409,7 @@ func TestConvertUntypedEntityToTypedEntity_ErrorCases(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			entity, err := ConvertUntypedEntityToTypedEntity(tt.untypedEntity)
+			entity, err := ConvertUntypedEntityToEntity(tt.untypedEntity)
 			require.Error(t, err)
 			require.Contains(t, err.Error(), tt.errContains)
 			require.Nil(t, entity)
@@ -417,7 +417,7 @@ func TestConvertUntypedEntityToTypedEntity_ErrorCases(t *testing.T) {
 	}
 }
 
-func TestConvertUntypedEntityToTypedEntity_ComplexEntityType(t *testing.T) {
+func TestConvertUntypedEntityToEntity_ComplexEntityType(t *testing.T) {
 	// Create a complex schema with definitions and references
 	complexSchema := &jsonschema.JSONSchemaCTI{
 		JSONSchemaGeneric: jsonschema.JSONSchemaGeneric{
@@ -495,7 +495,7 @@ func TestConvertUntypedEntityToTypedEntity_ComplexEntityType(t *testing.T) {
 		},
 	}
 
-	entity, err := ConvertUntypedEntityToTypedEntity(untypedEntity)
+	entity, err := ConvertUntypedEntityToEntity(untypedEntity)
 	require.NoError(t, err)
 	require.NotNil(t, entity)
 
@@ -547,7 +547,7 @@ func TestConvertUntypedEntityToTypedEntity_ComplexEntityType(t *testing.T) {
 	require.Equal(t, "complex/original.raml", entityType.SourceMap.OriginalPath)
 }
 
-func TestConvertUntypedEntityToTypedEntity_EdgeCases(t *testing.T) {
+func TestConvertUntypedEntityToEntity_EdgeCases(t *testing.T) {
 	tests := []struct {
 		name          string
 		untypedEntity *testUntypedEntity
@@ -597,7 +597,7 @@ func TestConvertUntypedEntityToTypedEntity_EdgeCases(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			entity, err := ConvertUntypedEntityToTypedEntity(tt.untypedEntity)
+			entity, err := ConvertUntypedEntityToEntity(tt.untypedEntity)
 			if tt.wantErr {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), tt.errContains)


### PR DESCRIPTION
- Simplify function name by removing redundant "Typed" qualifier
- Update all references and documentation
- Rename corresponding test functions for consistency