### PR TITLE
fix: allow nil annotations for entity type creation

### DIFF
--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -540,11 +540,14 @@ func NewEntityType(
 	schema *jsonschema.JSONSchemaCTI,
 	annotations map[GJsonPath]*Annotations,
 ) (*EntityType, error) {
-	switch {
-	case schema == nil:
+	if id == "" {
+		return nil, errors.New("identifier is empty")
+	}
+	if schema == nil {
 		return nil, errors.New("schema is nil")
-	case annotations == nil:
-		return nil, errors.New("annotations are nil")
+	}
+	if annotations == nil {
+		annotations = make(map[GJsonPath]*Annotations)
 	}
 
 	obj := &EntityType{
@@ -869,6 +872,9 @@ func (e *EntityType) IsNil() bool {
 
 // NewEntityInstance creates a new EntityInstance with the given CTI identifier and values.
 func NewEntityInstance(id string, values any) (*EntityInstance, error) {
+	if id == "" {
+		return nil, errors.New("identifier is empty")
+	}
 	if values == nil {
 		return nil, errors.New("values is nil")
 	}

--- a/metadata/metadata_untyped.go
+++ b/metadata/metadata_untyped.go
@@ -66,14 +66,6 @@ func ConvertUntypedEntityToEntity(untypedEntity UntypedEntity) (Entity, error) {
 
 	// If the entity has values but no schema, we treat it as an instance of an entity type.
 	if rawValues != nil {
-		var values any
-		if err := json.Unmarshal(rawValues, &values); err != nil {
-			return nil, fmt.Errorf("unmarshal values for %s: %w", untypedEntity.GetCTI(), err)
-		}
-		e, err := NewEntityInstance(untypedEntity.GetCTI(), values)
-		if err != nil {
-			return nil, fmt.Errorf("make entity instance: %w", err)
-		}
 		if !untypedEntity.GetFinal() {
 			return nil, fmt.Errorf("untyped entity %s is not final, cannot convert to typed entity instance", untypedEntity.GetCTI())
 		}
@@ -88,6 +80,14 @@ func ConvertUntypedEntityToEntity(untypedEntity UntypedEntity) (Entity, error) {
 		}
 		if untypedEntity.GetAnnotations() != nil {
 			return nil, fmt.Errorf("untyped entity %s has annotations, but it is not allowed for entity instances", untypedEntity.GetCTI())
+		}
+		var values any
+		if err := json.Unmarshal(rawValues, &values); err != nil {
+			return nil, fmt.Errorf("unmarshal values for %s: %w", untypedEntity.GetCTI(), err)
+		}
+		e, err := NewEntityInstance(untypedEntity.GetCTI(), values)
+		if err != nil {
+			return nil, fmt.Errorf("make entity instance: %w", err)
 		}
 		e.SetFinal(true)
 		e.SetResilient(untypedEntity.GetResilient())

--- a/metadata/metadata_untyped_test.go
+++ b/metadata/metadata_untyped_test.go
@@ -225,7 +225,6 @@ func TestConvertUntypedEntityToEntity_EntityType(t *testing.T) {
 				DisplayName: "Test Type",
 				Description: "A test entity type",
 				Schema:      simpleSchemaJSON,
-				Annotations: json.RawMessage(`{}`), // Empty but not nil
 				SourceMap: UntypedSourceMap{
 					TypeAnnotationReference: TypeAnnotationReference{
 						Name: "TestType",
@@ -259,7 +258,6 @@ func TestConvertUntypedEntityToEntity_EntityType(t *testing.T) {
 				CTI:          "cti.test.type.v1.0",
 				Final:        true,
 				Schema:       simpleSchemaJSON,
-				Annotations:  json.RawMessage(`{}`), // Empty but not nil
 				TraitsSchema: traitsSchemaJSON,
 				Traits:       json.RawMessage(`{"trait1": "traitValue"}`),
 			},
@@ -296,7 +294,6 @@ func TestConvertUntypedEntityToEntity_EntityType(t *testing.T) {
 			untypedEntity: &testUntypedEntity{
 				CTI:               "cti.test.type.v1.0",
 				Schema:            simpleSchemaJSON,
-				Annotations:       json.RawMessage(`{}`), // Empty but not nil
 				TraitsSchema:      traitsSchemaJSON,
 				TraitsAnnotations: json.RawMessage(`{".trait1": {"cti.cti": "trait.annotation"}}`), // Fixed JSON key
 			},
@@ -333,7 +330,6 @@ func TestConvertUntypedEntityToEntity_EntityType(t *testing.T) {
 			untypedEntity: &testUntypedEntity{
 				CTI:          "cti.test.type.v1.0",
 				Schema:       simpleSchemaJSON,
-				Annotations:  json.RawMessage(`{}`), // Empty but not nil
 				TraitsSchema: json.RawMessage(`invalid json`),
 			},
 			wantErr:     true,
@@ -344,7 +340,6 @@ func TestConvertUntypedEntityToEntity_EntityType(t *testing.T) {
 			untypedEntity: &testUntypedEntity{
 				CTI:               "cti.test.type.v1.0",
 				Schema:            simpleSchemaJSON,
-				Annotations:       json.RawMessage(`{}`), // Empty but not nil
 				TraitsSchema:      traitsSchemaJSON,
 				TraitsAnnotations: json.RawMessage(`invalid json`),
 			},
@@ -354,10 +349,9 @@ func TestConvertUntypedEntityToEntity_EntityType(t *testing.T) {
 		{
 			name: "entity type with invalid traits JSON",
 			untypedEntity: &testUntypedEntity{
-				CTI:         "cti.test.type.v1.0",
-				Schema:      simpleSchemaJSON,
-				Annotations: json.RawMessage(`{}`), // Empty but not nil
-				Traits:      json.RawMessage(`invalid json`),
+				CTI:    "cti.test.type.v1.0",
+				Schema: simpleSchemaJSON,
+				Traits: json.RawMessage(`invalid json`),
 			},
 			wantErr:     true,
 			errContains: "unmarshal traits for",
@@ -561,7 +555,6 @@ func TestConvertUntypedEntityToEntity_EdgeCases(t *testing.T) {
 				CTI:               "cti.test.type.v1.0",
 				Schema:            json.RawMessage(`{"type": "object"}`),
 				Traits:            json.RawMessage(`{}`),
-				Annotations:       json.RawMessage(`{}`), // Empty but not nil - this is valid
 				TraitsAnnotations: json.RawMessage(`{}`),
 			},
 			wantErr: false,
@@ -576,9 +569,8 @@ func TestConvertUntypedEntityToEntity_EdgeCases(t *testing.T) {
 		{
 			name: "entity with minimal required fields only",
 			untypedEntity: &testUntypedEntity{
-				CTI:         "cti.minimal.v1.0",
-				Schema:      json.RawMessage(`{"type": "string"}`),
-				Annotations: json.RawMessage(`{}`), // Empty but not nil
+				CTI:    "cti.minimal.v1.0",
+				Schema: json.RawMessage(`{"type": "string"}`),
 			},
 			wantErr: false,
 			validate: func(t *testing.T, entity Entity) {


### PR DESCRIPTION
- Change NewEntityType to allow nil annotations and initialize empty map instead of returning error
- Add empty string validation for entity ID in NewEntityType and NewEntityInstance