### PR TITLE
VP-5787 fix: drop orphan cti.schema annotations in transformer

### DIFF
--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -176,6 +176,27 @@ func (a *Annotations) ReadCTISchema() []string {
 	return vals
 }
 
+// IsEmpty reports whether every field of the Annotations struct holds its
+// zero value. It is used by callers that may need to drop annotation entries
+// whose fields have all been cleared (e.g. after filtering out an orphan
+// cti.schema reference).
+func (a *Annotations) IsEmpty() bool {
+	if a == nil {
+		return true
+	}
+	return a.ID == nil &&
+		a.AccessField == nil &&
+		a.DisplayName == nil &&
+		a.Description == nil &&
+		a.Reference == nil &&
+		a.Overridable == nil &&
+		a.Asset == nil &&
+		a.L10N == nil &&
+		a.Schema == nil &&
+		a.Meta == "" &&
+		len(a.PropertyNames) == 0
+}
+
 // ReadReference returns a slice of CTI reference values.
 // If the Reference annotation is a boolean, it returns a slice with that boolean as a string.
 // If it is a string, it returns a slice with that string.

--- a/metadata/metadata_test.go
+++ b/metadata/metadata_test.go
@@ -1178,3 +1178,32 @@ func TestAnnotations_ReadReference(t *testing.T) {
 		})
 	}
 }
+
+func TestAnnotations_IsEmpty(t *testing.T) {
+	truthy := true
+	tests := map[string]struct {
+		ann      *Annotations
+		expected bool
+	}{
+		"nil receiver":            {ann: nil, expected: true},
+		"zero value":              {ann: &Annotations{}, expected: true},
+		"ID set":                  {ann: &Annotations{ID: &truthy}, expected: false},
+		"AccessField set":         {ann: &Annotations{AccessField: &truthy}, expected: false},
+		"DisplayName set":         {ann: &Annotations{DisplayName: &truthy}, expected: false},
+		"Description set":         {ann: &Annotations{Description: &truthy}, expected: false},
+		"Reference set":           {ann: &Annotations{Reference: "x"}, expected: false},
+		"Overridable set":         {ann: &Annotations{Overridable: &truthy}, expected: false},
+		"Asset set":               {ann: &Annotations{Asset: &truthy}, expected: false},
+		"L10N set":                {ann: &Annotations{L10N: &truthy}, expected: false},
+		"Schema set as string":    {ann: &Annotations{Schema: "cti.x"}, expected: false},
+		"Schema set as list":      {ann: &Annotations{Schema: []any{"cti.x"}}, expected: false},
+		"Meta set":                {ann: &Annotations{Meta: "x"}, expected: false},
+		"PropertyNames non-empty": {ann: &Annotations{PropertyNames: map[string]any{"k": "v"}}, expected: false},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			require.Equal(t, tt.expected, tt.ann.IsEmpty())
+		})
+	}
+}

--- a/metadata/transformer/transformer.go
+++ b/metadata/transformer/transformer.go
@@ -142,7 +142,9 @@ func (t *Transformer) collectAnnotations() error {
 			if err != nil {
 				return fmt.Errorf("extract schema definition for %s: %w", cti, err)
 			}
-			entity.Annotations = ac.Collect(schema)
+			anns := ac.Collect(schema)
+			t.filterOrphanCTISchemas(anns)
+			entity.Annotations = anns
 		}
 		// collect annotations for traits schema
 		if entity.TraitsSchema != nil {
@@ -150,10 +152,50 @@ func (t *Transformer) collectAnnotations() error {
 			if err != nil {
 				return fmt.Errorf("extract schema definition for %s: %w", cti, err)
 			}
-			entity.TraitsAnnotations = ac.Collect(schema)
+			anns := ac.Collect(schema)
+			t.filterOrphanCTISchemas(anns)
+			entity.TraitsAnnotations = anns
 		}
 	}
 	return nil
+}
+
+// filterOrphanCTISchemas drops cti.schema references whose target CTI is not
+// present in the registry, then deletes any annotation entries that become
+// fully empty. This prevents downstream consumers from following an annotation
+// to an entity that doesn't exist (e.g. a callback whose schema declares a
+// `request` slot of an acgw.request CTI that was never defined in the
+// package).
+func (t *Transformer) filterOrphanCTISchemas(anns map[metadata.GJsonPath]*metadata.Annotations) {
+	for path, entry := range anns {
+		if entry == nil || entry.Schema == nil {
+			continue
+		}
+		refs := entry.ReadCTISchema()
+		kept := make([]string, 0, len(refs))
+		for _, ref := range refs {
+			if _, ok := t.registry.Index[ref]; ok {
+				kept = append(kept, ref)
+			}
+		}
+		if len(kept) != len(refs) {
+			switch len(kept) {
+			case 0:
+				entry.Schema = nil
+			case 1:
+				entry.Schema = kept[0]
+			default:
+				out := make([]any, len(kept))
+				for i, s := range kept {
+					out[i] = s
+				}
+				entry.Schema = out
+			}
+		}
+		if entry.IsEmpty() {
+			delete(anns, path)
+		}
+	}
 }
 
 func (t *Transformer) findAndInsertCtiSchemas() error {

--- a/metadata/transformer/transformer_test.go
+++ b/metadata/transformer/transformer_test.go
@@ -1,0 +1,103 @@
+package transformer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/acronis/go-cti/metadata"
+	"github.com/acronis/go-cti/metadata/jsonschema"
+	"github.com/acronis/go-cti/metadata/registry"
+)
+
+func newRegistryWith(t *testing.T, ctis ...string) *registry.MetadataRegistry {
+	t.Helper()
+	r := registry.New()
+	for _, id := range ctis {
+		ent, err := metadata.NewEntityType(id, &jsonschema.JSONSchemaCTI{}, nil)
+		require.NoError(t, err)
+		require.NoError(t, r.Add(ent))
+	}
+	return r
+}
+
+func TestFilterOrphanCTISchemas(t *testing.T) {
+	truthy := true
+	const (
+		presentReq  = "cti.a.p.acgw.request.v1.1~vendor.app.v1.0"
+		presentResA = "cti.a.p.acgw.response.v1.1~vendor.app.a.v1.0"
+		presentResB = "cti.a.p.acgw.response.v1.1~vendor.app.b.v1.0"
+		orphanA     = "cti.a.p.acgw.request.v1.1~missing.a.v1.0"
+		orphanB     = "cti.a.p.acgw.request.v1.1~missing.b.v1.0"
+	)
+
+	tests := []struct {
+		name    string
+		present []string
+		input   map[metadata.GJsonPath]*metadata.Annotations
+		want    map[metadata.GJsonPath]*metadata.Annotations
+	}{
+		{
+			name:  "orphan single string: entry dropped",
+			input: map[metadata.GJsonPath]*metadata.Annotations{".request": {Schema: orphanA}},
+			want:  map[metadata.GJsonPath]*metadata.Annotations{},
+		},
+		{
+			name:    "present single string: entry kept untouched",
+			present: []string{presentReq},
+			input:   map[metadata.GJsonPath]*metadata.Annotations{".request": {Schema: presentReq}},
+			want:    map[metadata.GJsonPath]*metadata.Annotations{".request": {Schema: presentReq}},
+		},
+		{
+			name:  "list all orphans: entry dropped",
+			input: map[metadata.GJsonPath]*metadata.Annotations{".responses.#": {Schema: []any{orphanA, orphanB}}},
+			want:  map[metadata.GJsonPath]*metadata.Annotations{},
+		},
+		{
+			name:    "list mixed with one survivor: collapses to string",
+			present: []string{presentResA},
+			input:   map[metadata.GJsonPath]*metadata.Annotations{".responses.#": {Schema: []any{orphanA, presentResA}}},
+			want:    map[metadata.GJsonPath]*metadata.Annotations{".responses.#": {Schema: presentResA}},
+		},
+		{
+			name:    "list mixed with multiple survivors: keeps list",
+			present: []string{presentResA, presentResB},
+			input:   map[metadata.GJsonPath]*metadata.Annotations{".responses.#": {Schema: []any{orphanA, presentResA, presentResB}}},
+			want:    map[metadata.GJsonPath]*metadata.Annotations{".responses.#": {Schema: []any{presentResA, presentResB}}},
+		},
+		{
+			name:  "orphan schema with other field set: schema cleared, entry kept",
+			input: map[metadata.GJsonPath]*metadata.Annotations{".request": {Schema: orphanA, Overridable: &truthy}},
+			want:  map[metadata.GJsonPath]*metadata.Annotations{".request": {Overridable: &truthy}},
+		},
+		{
+			name:  "nil schema with other field set: no-op",
+			input: map[metadata.GJsonPath]*metadata.Annotations{".request": {Overridable: &truthy}},
+			want:  map[metadata.GJsonPath]*metadata.Annotations{".request": {Overridable: &truthy}},
+		},
+		{
+			name:  "nil entry value: no panic, entry kept",
+			input: map[metadata.GJsonPath]*metadata.Annotations{".weird": nil},
+			want:  map[metadata.GJsonPath]*metadata.Annotations{".weird": nil},
+		},
+		{
+			name:    "multiple entries handled independently",
+			present: []string{presentReq},
+			input: map[metadata.GJsonPath]*metadata.Annotations{
+				".callback_with_request":    {Schema: presentReq},
+				".callback_without_request": {Schema: orphanA},
+			},
+			want: map[metadata.GJsonPath]*metadata.Annotations{
+				".callback_with_request": {Schema: presentReq},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tr := New(newRegistryWith(t, tt.present...))
+			tr.filterOrphanCTISchemas(tt.input)
+			require.Equal(t, tt.want, tt.input)
+		})
+	}
+}


### PR DESCRIPTION
 ## Problem                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                    
  The annotations collector emits a path-keyed entry for every schema                                                                                                                                                                               
  property that declares `cti.schema`, regardless of whether the                                                                                                                                                                                    
  referenced CTI is present in the registry. As a result, callbacks that                                                                                                                                                                            
  inherit the base `acgw.callback` schema end up with a `.request`                                                                                                                                                                                  
  annotation pointing at an `acgw.request` CTI that the cyberapp never                                                                                                                                                                              
  declared, which breaks runtime resolution downstream (consumer reports                                                                                                                                                                            
  `errGetCTIEntity: failed to get cti entity`).                                                                                                                                                                                                     
                                                                                                                                                                                                                                                    
  ## Fix                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                    
  Filter the orphan references in the transformer phase, where the full                                                                                                                                                                             
  registry is available. For each annotation entry, drop `cti.schema`                                                                                                                                                                               
  references that aren't in `registry.Index`. If the entry becomes empty                                                                                                                                                                            
  after filtering, delete it from the map. The annotations collector                                                                                                                                                                                
  stays schema-pure — no API change there. 